### PR TITLE
Update datex-tractor.

### DIFF
--- a/.github/workflows/todo-extractor.yml
+++ b/.github/workflows/todo-extractor.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
     push:
         branches:
-            - "release/*"
+            - "main"
 
 concurrency:
     group: ${{ github.workflow }}
@@ -32,13 +32,8 @@ jobs:
               with:
                 token: ${{ steps.app-token.outputs.token }}
 
-            - name: Set up Python...
-              uses: actions/setup-python@v5
-              with:
-                python-version: "3.13"
-
             - name: Run datex_tractor
-              uses: unyt-org/datex-tractor@r0.0.3
+              uses: unyt-org/datex-tractor@v0.0.1
               with:
                 # github_token: ${{ secrets.GITHUB_TOKEN }}
                 github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Addressing  issue #493

Update of datex-tractor to run only on push to main. 

> [!NOTE]
> Workflow triggers it self, and throws an error if self triggered from within the next run. Due to concurrency restrictions that's not real issue, just a little awkward (Still working on it :eyes: ).

> [!NOTE]
> [Pre-release notes](https://github.com/unyt-org/datex-tractor/releases/tag/v0.0.1) of datex-tractor version in use