### PR TITLE
Support for type inferfaces in DATEX

### DIFF
--- a/src/ast/grammar/function.rs
+++ b/src/ast/grammar/function.rs
@@ -6,14 +6,14 @@ use crate::ast::structs::expression::FunctionDeclaration;
 use crate::ast::structs::r#type::TypeExpression;
 use crate::ast::{DatexExpressionData, DatexParserTrait};
 use chumsky::prelude::*;
-fn return_type<'a>() -> impl DatexParserTrait<'a, Option<TypeExpression>> {
+pub fn return_type<'a>() -> impl DatexParserTrait<'a, Option<TypeExpression>> {
     just(Token::Arrow)
         .padded_by(whitespace())
         .ignore_then(ty().padded_by(whitespace()))
         .or_not()
 }
 
-fn body<'a>(
+pub fn body<'a>(
     statements: impl DatexParserTrait<'a>,
 ) -> impl DatexParserTrait<'a> {
     statements
@@ -21,7 +21,7 @@ fn body<'a>(
         .delimited_by(just(Token::LeftParen), just(Token::RightParen))
 }
 
-fn parameter<'a>() -> impl DatexParserTrait<'a, (String, TypeExpression)> {
+pub fn parameter<'a>() -> impl DatexParserTrait<'a, (String, TypeExpression)> {
     select! { Token::Identifier(name) => name }
         .then(
             just(Token::Colon)

--- a/src/ast/grammar/integer.rs
+++ b/src/ast/grammar/integer.rs
@@ -6,6 +6,7 @@ use crate::ast::spanned::Spanned;
 use crate::values::core_values::integer::Integer;
 use crate::values::core_values::integer::typed_integer::TypedInteger;
 use chumsky::prelude::*;
+
 pub fn integer<'a>() -> impl DatexParserTrait<'a> {
     select! {
         Token::DecimalIntegerLiteral(IntegerLiteral { value, variant }) => {

--- a/src/ast/grammar/interface.rs
+++ b/src/ast/grammar/interface.rs
@@ -1,0 +1,133 @@
+use chumsky::{IterParser, Parser, prelude::just, select};
+
+use crate::ast::{
+    DatexParserTrait,
+    grammar::{
+        function::{body, parameter, return_type},
+        utils::whitespace,
+    },
+    lexer::Token,
+    spanned::Spanned,
+    structs::{
+        expression::{
+            DatexExpressionData, FunctionDeclaration, InterfaceDeclaration,
+        },
+        r#type::{TypeExpression, TypeExpressionData},
+    },
+};
+
+pub fn self_parameter<'a>()
+-> impl DatexParserTrait<'a, (String, TypeExpression)> {
+    let amp = just(Token::Ampersand);
+    let mut_tok = just(Token::Mutable);
+
+    // &mut self | &self
+    let ref_forms = amp
+        .ignore_then(mut_tok.clone().or_not().padded_by(whitespace()))
+        .ignore_then(just(Token::Identifier("self".into())))
+        .to(("self".to_string(), TypeExpressionData::ReferenceSelf))
+        .map_with(|(name, data), e| (name, data.with_span(e.span())));
+
+    // self | mut self
+    let plain_forms = mut_tok
+        .or_not()
+        .ignore_then(just(Token::Identifier("self".into())))
+        .to(("self".to_string(), TypeExpressionData::ReferenceSelf))
+        .map_with(|(name, data), e| (name, data.with_span(e.span())));
+
+    ref_forms.or(plain_forms).padded_by(whitespace())
+}
+
+pub fn parameters<'a>()
+-> impl DatexParserTrait<'a, Vec<(String, TypeExpression)>> {
+    let maybe_self = self_parameter().padded_by(whitespace()).or_not();
+
+    let normal_params = parameter()
+        .padded_by(whitespace())
+        .separated_by(just(Token::Comma).padded_by(whitespace()))
+        .collect::<Vec<(String, TypeExpression)>>();
+
+    maybe_self
+        .then(
+            just(Token::Comma)
+                .padded_by(whitespace())
+                .ignore_then(normal_params.clone())
+                .or(normal_params),
+        )
+        .map(
+            |(self_opt, params): (
+                Option<(String, TypeExpression)>,
+                Vec<(String, TypeExpression)>,
+            )| {
+                if let Some(self_param) = self_opt {
+                    // Insert self parameter at the front
+                    let mut all = Vec::with_capacity(params.len() + 1);
+                    all.push(self_param);
+                    all.extend(params);
+                    all
+                } else {
+                    params
+                }
+            },
+        )
+        .delimited_by(just(Token::LeftParen), just(Token::RightParen))
+        .padded_by(whitespace())
+}
+
+fn method<'a>(
+    statements: impl DatexParserTrait<'a>,
+) -> impl DatexParserTrait<'a> {
+    let maybe_body = body(statements).map(Some);
+
+    select! { Token::Identifier(name) => name }
+        .padded_by(whitespace())
+        .then(parameters())
+        .then(return_type())
+        .then(
+            maybe_body
+                .or(just(Token::Semicolon).padded_by(whitespace()).to(None))
+                .or_not(),
+        )
+        .map_with(|(((name, params), return_type), body), e| {
+            let body_or_noop = body.flatten().unwrap_or_else(|| {
+                DatexExpressionData::Noop.with_default_span()
+            });
+            DatexExpressionData::FunctionDeclaration(FunctionDeclaration {
+                name,
+                parameters: params,
+                return_type,
+                body: Box::new(body_or_noop),
+            })
+            .with_span(e.span())
+        })
+}
+
+pub fn interface_declaration<'a>(
+    statements: impl DatexParserTrait<'a>,
+) -> impl DatexParserTrait<'a> {
+    let method_decl = method(statements);
+
+    let method_list = method_decl
+        .padded_by(whitespace())
+        .separated_by(whitespace())
+        .collect::<Vec<_>>()
+        .padded_by(whitespace())
+        .delimited_by(
+            just(Token::LeftCurly).padded_by(whitespace()),
+            just(Token::RightCurly).padded_by(whitespace()),
+        )
+        .padded_by(whitespace());
+
+    just(Token::Identifier("interface".to_string()))
+        .padded_by(whitespace())
+        .ignore_then(select! { Token::Identifier(name) => name })
+        .padded_by(whitespace())
+        .then(method_list)
+        .map_with(|(name, methods), e| {
+            DatexExpressionData::InterfaceDeclaration(InterfaceDeclaration {
+                name,
+                methods,
+            })
+            .with_span(e.span())
+        })
+}

--- a/src/ast/grammar/mod.rs
+++ b/src/ast/grammar/mod.rs
@@ -8,6 +8,7 @@ pub mod decimal;
 pub mod endpoint;
 pub mod function;
 pub mod integer;
+pub mod interface;
 pub mod key;
 pub mod list;
 pub mod literal;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -500,8 +500,14 @@ mod tests {
         let src = r#"
         interface User {
             can_vote(age: integer) -> boolean;
+
             is_adult(&self) -> boolean;
+
             is_senior(&self) -> boolean;
+
+            hurt(&mut self) -> void;
+
+            kill(self) -> void;
 
             get_name(&self) -> text (
                 self.name
@@ -578,10 +584,46 @@ mod tests {
                     .with_default_span(),
                     DatexExpressionData::FunctionDeclaration(
                         FunctionDeclaration {
+                            name: "hurt".to_string(),
+                            parameters: vec![(
+                                "self".to_string(),
+                                TypeExpressionData::ReferenceSelfMut
+                                    .with_default_span()
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal("void".to_string())
+                                    .with_default_span()
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::Noop.with_default_span()
+                            ),
+                        }
+                    )
+                    .with_default_span(),
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
+                            name: "kill".to_string(),
+                            parameters: vec![(
+                                "self".to_string(),
+                                TypeExpressionData::SelfType
+                                    .with_default_span()
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal("void".to_string())
+                                    .with_default_span()
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::Noop.with_default_span()
+                            ),
+                        }
+                    )
+                    .with_default_span(),
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
                             name: "get_name".to_string(),
                             parameters: vec![(
                                 "self".to_string(),
-                                TypeExpressionData::Literal("User".to_string())
+                                TypeExpressionData::ReferenceSelf
                                     .with_default_span()
                             )],
                             return_type: Some(

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -324,7 +324,8 @@ mod tests {
             structs::{
                 expression::{
                     ApplyChain, BinaryOperation, ComparisonOperation,
-                    FunctionDeclaration, TypeDeclaration, TypeDeclarationKind,
+                    FunctionDeclaration, InterfaceDeclaration, TypeDeclaration,
+                    TypeDeclarationKind,
                 },
                 r#type::{
                     Intersection, SliceList, StructuralMap, TypeExpression,
@@ -488,6 +489,90 @@ mod tests {
                     .with_default_span()
                 ),
             ]))
+        );
+    }
+
+    #[test]
+    fn interface() {
+        let src = r#"
+        interface User {
+            can_vote(age: integer) -> boolean;
+            is_adult(&self) -> boolean;
+            is_senior(&self) -> boolean;
+
+            get_name(&self) -> text (
+                self.name
+            )
+        }
+        "#;
+        let val = parse_unwrap_data(src);
+        assert_eq!(
+            val,
+            DatexExpressionData::InterfaceDeclaration(InterfaceDeclaration {
+                name: "User".to_string(),
+                methods: vec![
+                    FunctionDeclaration {
+                        name: "can_vote".to_string(),
+                        parameters: vec![(
+                            "age".to_string(),
+                            TypeExpressionData::Literal("integer".to_string())
+                                .with_default_span()
+                        )],
+                        return_type: Some(
+                            TypeExpressionData::Literal("boolean".to_string())
+                                .with_default_span()
+                        ),
+                        body: Box::new(
+                            DatexExpressionData::Noop.with_default_span()
+                        ),
+                    },
+                    FunctionDeclaration {
+                        name: "is_adult".to_string(),
+                        parameters: vec![(
+                            "self".to_string(),
+                            TypeExpressionData::Literal("User".to_string())
+                                .with_default_span()
+                        )],
+                        return_type: Some(
+                            TypeExpressionData::Literal("boolean".to_string())
+                                .with_default_span()
+                        ),
+                        body: Box::new(
+                            DatexExpressionData::Noop.with_default_span()
+                        ),
+                    },
+                    FunctionDeclaration {
+                        name: "is_senior".to_string(),
+                        parameters: vec![(
+                            "self".to_string(),
+                            TypeExpressionData::Literal("User".to_string())
+                                .with_default_span()
+                        )],
+                        return_type: Some(
+                            TypeExpressionData::Literal("boolean".to_string())
+                                .with_default_span()
+                        ),
+                        body: Box::new(
+                            DatexExpressionData::Noop.with_default_span()
+                        ),
+                    },
+                    FunctionDeclaration {
+                        name: "get_name".to_string(),
+                        parameters: vec![(
+                            "self".to_string(),
+                            TypeExpressionData::Literal("User".to_string())
+                                .with_default_span()
+                        )],
+                        return_type: Some(
+                            TypeExpressionData::Literal("boolean".to_string())
+                                .with_default_span()
+                        ),
+                        body: Box::new(
+                            DatexExpressionData::Noop.with_default_span()
+                        ),
+                    },
+                ],
+            })
         );
     }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -9,6 +9,7 @@ use crate::ast::grammar::binding::*;
 use crate::ast::grammar::chain::*;
 use crate::ast::grammar::comparison_operation::*;
 use crate::ast::grammar::function::*;
+use crate::ast::grammar::interface::interface_declaration;
 use crate::ast::grammar::key::*;
 use crate::ast::grammar::list::*;
 use crate::ast::grammar::map::*;
@@ -158,6 +159,7 @@ pub fn create_parser<'a>() -> impl DatexParserTrait<'a, DatexExpression> {
     let binary = binary_operation(chain);
 
     // FIXME #363 WIP
+    let interface_declaration = interface_declaration(statements.clone());
     let function_declaration = function(statements.clone());
 
     // comparison (==, !=, is, …)
@@ -232,6 +234,7 @@ pub fn create_parser<'a>() -> impl DatexParserTrait<'a, DatexExpression> {
             type_expression(),
             if_expression,
             declaration_or_assignment,
+            interface_declaration,
             function_declaration,
             comparison,
         ))
@@ -511,66 +514,102 @@ mod tests {
             DatexExpressionData::InterfaceDeclaration(InterfaceDeclaration {
                 name: "User".to_string(),
                 methods: vec![
-                    FunctionDeclaration {
-                        name: "can_vote".to_string(),
-                        parameters: vec![(
-                            "age".to_string(),
-                            TypeExpressionData::Literal("integer".to_string())
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
+                            name: "can_vote".to_string(),
+                            parameters: vec![(
+                                "age".to_string(),
+                                TypeExpressionData::Literal(
+                                    "integer".to_string()
+                                )
                                 .with_default_span()
-                        )],
-                        return_type: Some(
-                            TypeExpressionData::Literal("boolean".to_string())
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal(
+                                    "boolean".to_string()
+                                )
                                 .with_default_span()
-                        ),
-                        body: Box::new(
-                            DatexExpressionData::Noop.with_default_span()
-                        ),
-                    },
-                    FunctionDeclaration {
-                        name: "is_adult".to_string(),
-                        parameters: vec![(
-                            "self".to_string(),
-                            TypeExpressionData::Literal("User".to_string())
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::Noop.with_default_span()
+                            ),
+                        }
+                    )
+                    .with_default_span(),
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
+                            name: "is_adult".to_string(),
+                            parameters: vec![(
+                                "self".to_string(),
+                                TypeExpressionData::ReferenceSelf
+                                    .with_default_span()
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal(
+                                    "boolean".to_string()
+                                )
                                 .with_default_span()
-                        )],
-                        return_type: Some(
-                            TypeExpressionData::Literal("boolean".to_string())
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::Noop.with_default_span()
+                            ),
+                        }
+                    )
+                    .with_default_span(),
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
+                            name: "is_senior".to_string(),
+                            parameters: vec![(
+                                "self".to_string(),
+                                TypeExpressionData::ReferenceSelf
+                                    .with_default_span()
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal(
+                                    "boolean".to_string()
+                                )
                                 .with_default_span()
-                        ),
-                        body: Box::new(
-                            DatexExpressionData::Noop.with_default_span()
-                        ),
-                    },
-                    FunctionDeclaration {
-                        name: "is_senior".to_string(),
-                        parameters: vec![(
-                            "self".to_string(),
-                            TypeExpressionData::Literal("User".to_string())
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::Noop.with_default_span()
+                            ),
+                        }
+                    )
+                    .with_default_span(),
+                    DatexExpressionData::FunctionDeclaration(
+                        FunctionDeclaration {
+                            name: "get_name".to_string(),
+                            parameters: vec![(
+                                "self".to_string(),
+                                TypeExpressionData::Literal("User".to_string())
+                                    .with_default_span()
+                            )],
+                            return_type: Some(
+                                TypeExpressionData::Literal("text".to_string())
+                                    .with_default_span()
+                            ),
+                            body: Box::new(
+                                DatexExpressionData::ApplyChain(ApplyChain {
+                                    base: Box::new(
+                                        DatexExpressionData::Identifier(
+                                            "self".to_string()
+                                        )
+                                        .with_default_span()
+                                    ),
+                                    operations: vec![
+                                        ApplyOperation::PropertyAccess(
+                                            DatexExpressionData::Text(
+                                                "name".to_string()
+                                            )
+                                            .with_default_span()
+                                        )
+                                    ]
+                                })
                                 .with_default_span()
-                        )],
-                        return_type: Some(
-                            TypeExpressionData::Literal("boolean".to_string())
-                                .with_default_span()
-                        ),
-                        body: Box::new(
-                            DatexExpressionData::Noop.with_default_span()
-                        ),
-                    },
-                    FunctionDeclaration {
-                        name: "get_name".to_string(),
-                        parameters: vec![(
-                            "self".to_string(),
-                            TypeExpressionData::Literal("User".to_string())
-                                .with_default_span()
-                        )],
-                        return_type: Some(
-                            TypeExpressionData::Literal("boolean".to_string())
-                                .with_default_span()
-                        ),
-                        body: Box::new(
-                            DatexExpressionData::Noop.with_default_span()
-                        ),
-                    },
+                            ),
+                        }
+                    )
+                    .with_default_span(),
                 ],
             })
         );

--- a/src/ast/structs/expression.rs
+++ b/src/ast/structs/expression.rs
@@ -292,7 +292,7 @@ pub struct Conditional {
 #[derive(Clone, Debug, PartialEq)]
 pub struct InterfaceDeclaration {
     pub name: String,
-    pub methods: Vec<FunctionDeclaration>,
+    pub methods: Vec<DatexExpression>, // should always be FunctionDeclaration
 }
 
 impl Display for InterfaceDeclaration {

--- a/src/ast/structs/expression.rs
+++ b/src/ast/structs/expression.rs
@@ -170,6 +170,9 @@ pub enum DatexExpressionData {
 
     /// Variant access, e.g. integer/u8
     VariantAccess(VariantAccess),
+
+    /// Interface declaration, e.g. interface MyInterface { ... }
+    InterfaceDeclaration(InterfaceDeclaration),
 }
 
 impl Spanned for DatexExpressionData {
@@ -284,6 +287,18 @@ pub struct Conditional {
     pub condition: Box<DatexExpression>,
     pub then_branch: Box<DatexExpression>,
     pub else_branch: Option<Box<DatexExpression>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct InterfaceDeclaration {
+    pub name: String,
+    pub methods: Vec<FunctionDeclaration>,
+}
+
+impl Display for InterfaceDeclaration {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "interface {}", self.name)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/ast/structs/type.rs
+++ b/src/ast/structs/type.rs
@@ -62,6 +62,9 @@ pub enum TypeExpressionData {
     RefMut(Box<TypeExpression>),
 
     VariantAccess(TypeVariantAccess),
+
+    // The `self` type in methods
+    ReferenceSelf,
 }
 
 impl Spanned for TypeExpressionData {

--- a/src/ast/structs/type.rs
+++ b/src/ast/structs/type.rs
@@ -65,6 +65,8 @@ pub enum TypeExpressionData {
 
     // The `self` type in methods
     ReferenceSelf,
+    ReferenceSelfMut,
+    SelfType,
 }
 
 impl Spanned for TypeExpressionData {

--- a/src/decompiler/ast_to_source_code.rs
+++ b/src/decompiler/ast_to_source_code.rs
@@ -218,7 +218,9 @@ impl AstToSourceCodeFormatter {
         type_expr: &TypeExpression,
     ) -> String {
         match &type_expr.data {
-            TypeExpressionData::ReferenceSelf => "self".to_string(),
+            TypeExpressionData::ReferenceSelf => "&self".to_string(),
+            TypeExpressionData::ReferenceSelfMut => "&mut self".to_string(),
+            TypeExpressionData::SelfType => "self".to_string(),
             TypeExpressionData::VariantAccess(TypeVariantAccess {
                 name,
                 variant,

--- a/src/decompiler/ast_to_source_code.rs
+++ b/src/decompiler/ast_to_source_code.rs
@@ -218,6 +218,7 @@ impl AstToSourceCodeFormatter {
         type_expr: &TypeExpression,
     ) -> String {
         match &type_expr.data {
+            TypeExpressionData::ReferenceSelf => "self".to_string(),
             TypeExpressionData::VariantAccess(TypeVariantAccess {
                 name,
                 variant,

--- a/src/decompiler/ast_to_source_code.rs
+++ b/src/decompiler/ast_to_source_code.rs
@@ -454,6 +454,9 @@ impl AstToSourceCodeFormatter {
 
     pub fn format(&self, ast: &DatexExpression) -> String {
         match &ast.data {
+            DatexExpressionData::InterfaceDeclaration(_) => {
+                todo!("Not implemented: DatexExpressionData::Interface")
+            }
             DatexExpressionData::VariantAccess(VariantAccess {
                 name,
                 variant,

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -120,6 +120,7 @@ impl<'a> Formatter<'a> {
         let a = &self.alloc;
         println!("formatting type expression: {:?}", type_expr);
         match &type_expr.data {
+            TypeExpressionData::ReferenceSelf => a.text("self"),
             TypeExpressionData::VariantAccess(TypeVariantAccess {
                 name,
                 variant,

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -120,7 +120,9 @@ impl<'a> Formatter<'a> {
         let a = &self.alloc;
         println!("formatting type expression: {:?}", type_expr);
         match &type_expr.data {
-            TypeExpressionData::ReferenceSelf => a.text("self"),
+            TypeExpressionData::ReferenceSelf => a.text("&self"),
+            TypeExpressionData::ReferenceSelfMut => a.text("&mut self"),
+            TypeExpressionData::SelfType => a.text("self"),
             TypeExpressionData::VariantAccess(TypeVariantAccess {
                 name,
                 variant,

--- a/src/visitor/expression/mod.rs
+++ b/src/visitor/expression/mod.rs
@@ -4,9 +4,9 @@ use core::ops::Range;
 use crate::ast::structs::expression::{
     ApplyChain, BinaryOperation, ComparisonOperation, Conditional, CreateRef,
     DatexExpression, DatexExpressionData, Deref, DerefAssignment,
-    FunctionDeclaration, List, Map, RemoteExecution, Slot, SlotAssignment,
-    Statements, TypeDeclaration, UnaryOperation, VariableAccess,
-    VariableAssignment, VariableDeclaration, VariantAccess,
+    FunctionDeclaration, InterfaceDeclaration, List, Map, RemoteExecution,
+    Slot, SlotAssignment, Statements, TypeDeclaration, UnaryOperation,
+    VariableAccess, VariableAssignment, VariableDeclaration, VariantAccess,
 };
 use crate::values::core_values::decimal::Decimal;
 use crate::values::core_values::decimal::typed_decimal::TypedDecimal;
@@ -53,6 +53,10 @@ pub trait ExpressionVisitor<E>: TypeExpressionVisitor<E> {
     ) -> Result<(), E> {
         self.before_visit_datex_expression(expr);
         let visit_result = match &mut expr.data {
+            DatexExpressionData::InterfaceDeclaration(
+                interface_declaration,
+            ) => self
+                .visit_interface_declaration(interface_declaration, &expr.span),
             DatexExpressionData::VariantAccess(variant_access) => {
                 self.visit_variant_access(variant_access, &expr.span)
             }
@@ -235,6 +239,17 @@ pub trait ExpressionVisitor<E>: TypeExpressionVisitor<E> {
     ) -> ExpressionVisitResult<E> {
         let _ = span;
         let _ = variant_access;
+        Ok(VisitAction::VisitChildren)
+    }
+
+    /// Visit interface declaration
+    fn visit_interface_declaration(
+        &mut self,
+        interface_declaration: &mut InterfaceDeclaration,
+        span: &Range<usize>,
+    ) -> ExpressionVisitResult<E> {
+        let _ = span;
+        let _ = interface_declaration;
         Ok(VisitAction::VisitChildren)
     }
 

--- a/src/visitor/expression/visitable.rs
+++ b/src/visitor/expression/visitable.rs
@@ -2,9 +2,9 @@ use crate::ast::structs::apply_operation::ApplyOperation;
 use crate::ast::structs::expression::{
     ApplyChain, BinaryOperation, ComparisonOperation, Conditional, CreateRef,
     DatexExpression, DatexExpressionData, Deref, DerefAssignment,
-    FunctionDeclaration, List, Map, RemoteExecution, SlotAssignment,
-    Statements, TypeDeclaration, UnaryOperation, VariableAssignment,
-    VariableDeclaration,
+    FunctionDeclaration, InterfaceDeclaration, List, Map, RemoteExecution,
+    SlotAssignment, Statements, TypeDeclaration, UnaryOperation,
+    VariableAssignment, VariableDeclaration,
 };
 use crate::visitor::VisitAction;
 use crate::visitor::expression::ExpressionVisitor;
@@ -213,12 +213,27 @@ impl<E> VisitableExpression<E> for CreateRef {
     }
 }
 
+impl<E> VisitableExpression<E> for InterfaceDeclaration {
+    fn walk_children(
+        &mut self,
+        visitor: &mut impl ExpressionVisitor<E>,
+    ) -> Result<(), E> {
+        for method in &mut self.methods {
+            method.walk_children(visitor)?;
+        }
+        Ok(())
+    }
+}
+
 impl<E> VisitableExpression<E> for DatexExpression {
     fn walk_children(
         &mut self,
         visitor: &mut impl ExpressionVisitor<E>,
     ) -> Result<(), E> {
         match &mut self.data {
+            DatexExpressionData::InterfaceDeclaration(interface) => {
+                interface.walk_children(visitor)
+            }
             DatexExpressionData::BinaryOperation(op) => {
                 op.walk_children(visitor)
             }

--- a/src/visitor/type_expression/mod.rs
+++ b/src/visitor/type_expression/mod.rs
@@ -49,7 +49,9 @@ pub trait TypeExpressionVisitor<E>: Sized {
         self.before_visit_type_expression(expr);
 
         let visit_result = match &mut expr.data {
-            TypeExpressionData::ReferenceSelf => {
+            TypeExpressionData::ReferenceSelf
+            | TypeExpressionData::ReferenceSelfMut
+            | TypeExpressionData::SelfType => {
                 todo!("Visiting 'self' type expression is not yet implemented")
             }
             TypeExpressionData::VariantAccess(variant_access) => {

--- a/src/visitor/type_expression/mod.rs
+++ b/src/visitor/type_expression/mod.rs
@@ -49,6 +49,9 @@ pub trait TypeExpressionVisitor<E>: Sized {
         self.before_visit_type_expression(expr);
 
         let visit_result = match &mut expr.data {
+            TypeExpressionData::ReferenceSelf => {
+                todo!("Visiting 'self' type expression is not yet implemented")
+            }
             TypeExpressionData::VariantAccess(variant_access) => {
                 self.visit_variant_access_type(variant_access, &expr.span)
             }

--- a/src/visitor/type_expression/visitable.rs
+++ b/src/visitor/type_expression/visitable.rs
@@ -147,6 +147,8 @@ impl<E> VisitableTypeExpression<E> for TypeExpression {
             | TypeExpressionData::Text(_)
             | TypeExpressionData::VariantAccess(_)
             | TypeExpressionData::ReferenceSelf
+            | TypeExpressionData::ReferenceSelfMut
+            | TypeExpressionData::SelfType
             | TypeExpressionData::Endpoint(_) => Ok(()),
         }
     }

--- a/src/visitor/type_expression/visitable.rs
+++ b/src/visitor/type_expression/visitable.rs
@@ -146,6 +146,7 @@ impl<E> VisitableTypeExpression<E> for TypeExpression {
             | TypeExpressionData::Boolean(_)
             | TypeExpressionData::Text(_)
             | TypeExpressionData::VariantAccess(_)
+            | TypeExpressionData::ReferenceSelf
             | TypeExpressionData::Endpoint(_) => Ok(()),
         }
     }


### PR DESCRIPTION
This PR adds support for interfaces for DATEX types.

```ts
// type definition
type User = {
    name: text,
    age: integer/u8
};

// generic interface definition
interface Human {
    // "static"
    can_vote(age: integer) -> boolean;
    
    // self references
    is_adult(&self) -> boolean;
    is_senior(&self) -> boolean;
    
    // mut self reference
    hurt(&mut self) -> void;
    
    // self type
    kill(self) -> void;

    // default implementation (shall we allow that?)
    get_name(&self) -> text (
        "X Æ A-XII"
    )
}

// impl for concrete type
User implements Human {
    can_vote(age: integer) -> boolean (
       age >= 18
    )
    is_adult(&self) -> boolean (
        self.name is not "peter pan"
    )
    hurt(&mut self) -> void (
       self.age += 10
    )
    kill(self) -> void ()
};
```


```ts
// type definition
type User = {
    name: text,
    age: integer/u8
};

// anonymous "interface"
interface for User {
     is_ugly(&self) -> boolean (
        return self.age < 42
     )
}

// or 
interface X {
   is_ugly(&self) -> boolean;
}
type User = {
    name: text,
    age: integer/u8
} implements X;
```

* [ ] Implement draft / proposal into grammar
   * [ ] Interface parsing
   * [ ] Generics
   * [ ] Type extends
* [ ] Implement precompiler
* [ ] Implement type inference
* [ ] Implement compiler
* [ ] Implement runtime / execution
* [ ] Implement DIF