### PR TITLE
Fix: treat CR as whitespace in lexer.rs to support CRLF in Windows

### DIFF
--- a/src/ast/lexer.rs
+++ b/src/ast/lexer.rs
@@ -190,7 +190,7 @@ pub enum Token {
     // named slots (starting with #, followed by A-Z or a-z)
     #[regex(r"#[_a-zA-Z]+", allocated_string)] NamedSlot(String),
 
-    #[regex(r"[ \t\n\f]")]
+    #[regex(r"[ \t\n\r\f]")]
     Whitespace,
 
 


### PR DESCRIPTION
Added handling for carriage return (\r) in the whitespace token in lexer.rs.
This fixes parsing related JSON failures during testing on windows caused by CRLF line endings.

Change: whitespace regex [ \t\n\f] → [ \t\n\r\f]